### PR TITLE
Added 3RMXi to the gh-pages Boilerplates

### DIFF
--- a/docs/faq/boilerplates.md
+++ b/docs/faq/boilerplates.md
@@ -5,6 +5,7 @@
 * [MobX + React JSFiddle](https://jsfiddle.net/mweststrate/wgbe4guu/)
 * [MobX + React JSFiddle with just ES5](https://jsfiddle.net/rubyred/55oc981v/)
 * [custom-react-scripts](https://www.npmjs.com/package/custom-react-scripts) for [create-react-app](https://github.com/facebookincubator/create-react-app) that enables using decorators; add `REACT_APP_DECORATORS=true` to `.env` to enable decorators.
+[React + React Router 4 + MobX + i18n](https://github.com/alexvcasillas/react-mobx-router) React Create App with React Router and MobX and Internationalization
 * [generator-mobx-react](https://www.npmjs.com/package/generator-mobx-react) Yeoman MobX, React, Webpack, Babel / Typescript project generator
 * [mobx-starter](https://github.com/nightwolfz/mobx-starter): Starting base for an mobx react project with optional isomorphism. MongoDB auth & sessions, hot reload, react-router
 * [React, React-Router 4, MobX and Webpack 2-boilerplate with async routes](https://github.com/mhaagens/react-mobx-react-router4-boilerplate)


### PR DESCRIPTION
Pull request to add #3RMXi to the MobX Boilerplates' docs.

Thanks for taking the effort to create a PR!

If you are creating an extensive PR, you might want to open an issue with your idea first, so that you don't put a lot of effort in an PR that wouldn't be accepted. Please prepend pull requests with `WIP: ` if they are not yet finished
PR checklist:

* [ ] Added unit tests
* [ ] Updated changelog
* [x] Updated docs (either in the description of this PR as markdown, or as separate PR on the `gh-pages` branch. Please refer to this PR). For new functionality, at least [API.md](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md) should be updated
* [ ] Added typescript typings
* [ ] Verified that there is no significant performance drop (`npm run perf`)

Feel free to ask help with any of these boxes!

The above process doesn't apply to doc updates etc.
